### PR TITLE
Fixes rate limit bypass for API/MCP

### DIFF
--- a/web/src/lib/lookup/api-helpers.ts
+++ b/web/src/lib/lookup/api-helpers.ts
@@ -37,16 +37,19 @@ export const OPTIONS: APIRoute = () =>
 export const ALL: APIRoute = () =>
   error(405, "Method not allowed", { Allow: "GET, OPTIONS" });
 
-export function getClientIp(request: Request): string {
-  return (
-    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
-    request.headers.get("x-real-ip") ||
-    "unknown"
-  );
+const env = import.meta.env as unknown as Record<string, string | undefined>;
+const IP_HEADER =
+  env.CLIENT_IP_HEADER || process.env.CLIENT_IP_HEADER || "cf-connecting-ip";
+
+function getClientIp(request: Request): string {
+  return request.headers.get(IP_HEADER) || "unknown";
 }
 
-export function enforceRateLimit(ip: string): Response | null {
-  const limit = checkRateLimit(ip);
+export function enforceRateLimit(
+  request: Request,
+  scope = "",
+): Response | null {
+  const limit = checkRateLimit(scope + getClientIp(request));
   if (!limit.ok) {
     return error(429, limit.message, {
       "Retry-After": String(limit.retryAfter),

--- a/web/src/pages/api/lookup/app.ts
+++ b/web/src/pages/api/lookup/app.ts
@@ -8,7 +8,6 @@ import {
   error,
   OPTIONS,
   ALL,
-  getClientIp,
   enforceRateLimit,
 } from "@lib/lookup/api-helpers";
 
@@ -16,7 +15,7 @@ export const prerender = false;
 export { OPTIONS, ALL };
 
 export const GET: APIRoute = async ({ url, request }) => {
-  const limited = enforceRateLimit(getClientIp(request));
+  const limited = enforceRateLimit(request);
   if (limited) return limited;
 
   const id = url.searchParams.get("id");

--- a/web/src/pages/api/lookup/forge.ts
+++ b/web/src/pages/api/lookup/forge.ts
@@ -7,7 +7,6 @@ import {
   error,
   OPTIONS,
   ALL,
-  getClientIp,
   enforceRateLimit,
 } from "@lib/lookup/api-helpers";
 
@@ -15,7 +14,7 @@ export const prerender = false;
 export { OPTIONS, ALL };
 
 export const GET: APIRoute = async ({ url, request }) => {
-  const limited = enforceRateLimit(getClientIp(request));
+  const limited = enforceRateLimit(request);
   if (limited) return limited;
 
   const input = url.searchParams.get("repo");

--- a/web/src/pages/api/lookup/github.ts
+++ b/web/src/pages/api/lookup/github.ts
@@ -8,7 +8,6 @@ import {
   error,
   OPTIONS,
   ALL,
-  getClientIp,
   enforceRateLimit,
 } from "@lib/lookup/api-helpers";
 
@@ -16,7 +15,7 @@ export const prerender = false;
 export { OPTIONS, ALL };
 
 export const GET: APIRoute = async ({ url, request }) => {
-  const limited = enforceRateLimit(getClientIp(request));
+  const limited = enforceRateLimit(request);
   if (limited) return limited;
 
   if (!hasGitHubToken()) {

--- a/web/src/pages/api/lookup/package.ts
+++ b/web/src/pages/api/lookup/package.ts
@@ -8,7 +8,6 @@ import {
   error,
   OPTIONS,
   ALL,
-  getClientIp,
   enforceRateLimit,
 } from "@lib/lookup/api-helpers";
 
@@ -18,7 +17,7 @@ export { OPTIONS, ALL };
 const VALID_REGISTRIES = new Set<PackageRegistry>(["npm", "pypi", "crates"]);
 
 export const GET: APIRoute = async ({ url, request }) => {
-  const limited = enforceRateLimit(getClientIp(request));
+  const limited = enforceRateLimit(request);
   if (limited) return limited;
 
   const name = url.searchParams.get("name");

--- a/web/src/pages/api/lookup/website.ts
+++ b/web/src/pages/api/lookup/website.ts
@@ -8,7 +8,6 @@ import {
   error,
   OPTIONS,
   ALL,
-  getClientIp,
   enforceRateLimit,
 } from "@lib/lookup/api-helpers";
 
@@ -16,7 +15,7 @@ export const prerender = false;
 export { OPTIONS, ALL };
 
 export const GET: APIRoute = async ({ url, request }) => {
-  const limited = enforceRateLimit(getClientIp(request));
+  const limited = enforceRateLimit(request);
   if (limited) return limited;
 
   const input = url.searchParams.get("url");

--- a/web/src/pages/api/submit-anonymous.json.ts
+++ b/web/src/pages/api/submit-anonymous.json.ts
@@ -1,4 +1,5 @@
 import type { APIRoute } from "astro";
+import { enforceRateLimit } from "@lib/lookup/api-helpers";
 
 export const prerender = false;
 
@@ -15,6 +16,9 @@ const json = (status: number, payload: unknown) =>
 // call gitgost.fly.dev directly because of CORS, so the form posts here
 // and we forward the request with the anonymous key header.
 export const POST: APIRoute = async ({ request }) => {
+  const limited = enforceRateLimit(request, "submit:");
+  if (limited) return limited;
+
   let payload: { title?: unknown; body?: unknown };
   try {
     payload = await request.json();


### PR DESCRIPTION
Fixes spoofable rate-limit IP, adds limit to submit endpoint, so we use trusted edge IP for limiting

Fixes #152