### PR TITLE
Add BlazePhoenix to independent programs

### DIFF
--- a/independent-programs.yml
+++ b/independent-programs.yml
@@ -246,6 +246,36 @@ companies:
     medium: 300
     low: 150
 
+- company: BlazePhoenix
+  url: https://blazephoenix.xyz/bounty
+  contact: mailto:contact@blazephoenix.xyz
+  rewards:
+  - '*bounty'
+  program_type: bounty
+  status: active
+  min_payout: 100000
+  max_payout: 6000000
+  currency: BZPX
+  safe_harbor: full
+  allows_disclosure: true
+  response_sla_days: 3
+  preferred_languages: English, Portuguese
+  hall_of_fame_url: https://blazephoenix.xyz/bounty
+  reporting_url: mailto:contact@blazephoenix.xyz
+  legal_terms_url: https://github.com/blazephoenixxyz-crypto/Blaze-Phoenix-Dex/blob/main/SECURITY.md
+  description: Smart-contract bug bounty across two on-chain protocols, an EVM DEX aggregator and a solvency-enforced staking engine, with 40,000,000 BZPX allocated in total. Rewards are paid in the project's own token, which is not liquid at the time of writing, so the programme commits to the quantity of tokens and the schedule rather than to a value; settlement of awards begins after October 2026, while reports are accepted, triaged and acknowledged from now. Severity is assessed by the project and argued in writing where it differs from the reporter's own rating.
+  scope:
+  - Solidity contracts of the DEX aggregator (Router, Solver, Hub, Quoter, Core)
+  - Solidity contracts of the staking engine (BlazePhoenixStaking, BlazePhoenixMathLib)
+  out_of_scope:
+  - Third-party AMM pools, tokens and bridges the protocol reads from
+  - RPC providers and front-ends
+  - Theoretical concerns without demonstrated impact
+  excluded_methods:
+  - dos
+  - social_engineering
+  standards:
+  - security.txt
 - company: BSI Germany
   url: https://www.bsi.bund.de/EN/IT-Sicherheitsvorfall/IT-Schwachstellen/it-schwachstellen_node.html
   contact: mailto:vulnerability@bsi.bund.de

--- a/independent-programs.yml
+++ b/independent-programs.yml
@@ -226,6 +226,38 @@ companies:
   currency: USD
   disclosure_timeline_days: 90
 
+- company: BlazePhoenix
+  url: https://blazephoenix.xyz/bounty
+  contact: mailto:contact@blazephoenix.xyz
+  rewards:
+  - '*bounty'
+  program_type: bounty
+  status: active
+  min_payout: 100000
+  max_payout: 6000000
+  currency: BZPX
+  safe_harbor: full
+  allows_disclosure: true
+  response_sla_days: 3
+  preferred_languages: English, Portuguese
+  hall_of_fame_url: https://blazephoenix.xyz/bounty
+  legal_terms_url: https://github.com/blazephoenixxyz-crypto/Blaze-Phoenix-Dex/blob/main/SECURITY.md
+  description: Smart-contract bug bounty across two on-chain protocols, an EVM DEX aggregator and a solvency-enforced staking engine, with 40,000,000 BZPX allocated. Rewards are paid in the project's own token, which is not yet liquid, so the programme commits to a quantity of tokens and a schedule rather than to a value; settlement begins after October 2026, though reports are triaged from now. Severity is assessed by the project, with written reasoning where it differs from the reporter's rating.
+  scope:
+  - target: Solidity contracts of the DEX aggregator (Router, Solver, Hub, Quoter, Core)
+    type: other
+  - target: Solidity contracts of the staking engine (BlazePhoenixStaking, BlazePhoenixMathLib)
+    type: other
+  out_of_scope:
+  - Third-party AMM pools, tokens and bridges the protocol reads from
+  - RPC providers and front-ends
+  - Theoretical concerns without demonstrated impact
+  excluded_methods:
+  - dos
+  - social_engineering
+  standards:
+  - security.txt
+
 - company: boldcommerce.com
   url: https://boldcommerce.com/bug-bounty
   contact: mailto:bugbounty@boldcommerce.com
@@ -246,36 +278,6 @@ companies:
     medium: 300
     low: 150
 
-- company: BlazePhoenix
-  url: https://blazephoenix.xyz/bounty
-  contact: mailto:contact@blazephoenix.xyz
-  rewards:
-  - '*bounty'
-  program_type: bounty
-  status: active
-  min_payout: 100000
-  max_payout: 6000000
-  currency: BZPX
-  safe_harbor: full
-  allows_disclosure: true
-  response_sla_days: 3
-  preferred_languages: English, Portuguese
-  hall_of_fame_url: https://blazephoenix.xyz/bounty
-  reporting_url: mailto:contact@blazephoenix.xyz
-  legal_terms_url: https://github.com/blazephoenixxyz-crypto/Blaze-Phoenix-Dex/blob/main/SECURITY.md
-  description: Smart-contract bug bounty across two on-chain protocols, an EVM DEX aggregator and a solvency-enforced staking engine, with 40,000,000 BZPX allocated in total. Rewards are paid in the project's own token, which is not liquid at the time of writing, so the programme commits to the quantity of tokens and the schedule rather than to a value; settlement of awards begins after October 2026, while reports are accepted, triaged and acknowledged from now. Severity is assessed by the project and argued in writing where it differs from the reporter's own rating.
-  scope:
-  - Solidity contracts of the DEX aggregator (Router, Solver, Hub, Quoter, Core)
-  - Solidity contracts of the staking engine (BlazePhoenixStaking, BlazePhoenixMathLib)
-  out_of_scope:
-  - Third-party AMM pools, tokens and bridges the protocol reads from
-  - RPC providers and front-ends
-  - Theoretical concerns without demonstrated impact
-  excluded_methods:
-  - dos
-  - social_engineering
-  standards:
-  - security.txt
 - company: BSI Germany
   url: https://www.bsi.bund.de/EN/IT-Sicherheitsvorfall/IT-Schwachstellen/it-schwachstellen_node.html
   contact: mailto:vulnerability@bsi.bund.de


### PR DESCRIPTION
Adds **BlazePhoenix** to `independent-programs.yml`, in alphabetical position between Bambu Lab and BSI Germany.

A smart-contract bug bounty across two on-chain protocols — an EVM DEX aggregator and a solvency-enforced staking engine — with 40,000,000 tokens allocated.

Two fields deserve a word rather than being left for someone to discover:

**`currency: BZPX`** — rewards are paid in the project's own token, which is not liquid at the time of writing. The programme commits to the quantity and the schedule, not to a value. The `min_payout`/`max_payout` figures are therefore token counts and should be read as such.

**`status: active`** — reports are accepted, triaged and acknowledged now, with a 3-day response target, but settlement of awards begins after October 2026. If this directory would rather record that as something other than `active` until payouts actually start, that is a fair reading and I will change it to whatever you prefer.

`safe_harbor: full` is backed by an explicit clause in the policy: good-faith research is authorised, no legal action will be pursued or supported for it, and if a third party brings one the authorisation will be made known publicly and in writing.

- Policy: https://github.com/blazephoenixxyz-crypto/Blaze-Phoenix-Dex/blob/main/SECURITY.md
- security.txt: https://blazephoenix.xyz/.well-known/security.txt