### PR TITLE
Add programs: Passbolt and Pulumi

### DIFF
--- a/independent-programs.yml
+++ b/independent-programs.yml
@@ -1276,6 +1276,47 @@ companies:
   payout_table:
     high: 1000
 
+- company: Passbolt
+  url: https://www.passbolt.com/docs/contribute/security/vulnerability/
+  contact: mailto:security@passbolt.com
+  rewards:
+  - '*recognition'
+  program_type: vdp
+  status: active
+  safe_harbor: partial
+  preferred_languages: English
+  pgp_key: https://keys.mailvelope.com/pks/lookup?op=get&search=security%40passbolt.com
+  description: Passbolt runs its own coordinated disclosure process covering the passbolt server, browser extension, styleguide, Windows app and mobile clients. There is no financial reward; valid reports are credited in the published vulnerability report and across Passbolt's social media. Reports are acknowledged within 48 hours, and Passbolt commits to taking no legal action over the research. Testing must be done against a self-hosted install rather than the public website.
+  excluded_methods:
+  - dos
+  - social_engineering
+  - physical_access
+  scope:
+  - target: passbolt_api
+    type: web
+  - target: passbolt_pro_api
+    type: web
+  - target: passbolt_browser_extension
+    type: web
+  - target: passbolt_styleguide
+    type: web
+  - target: passbolt-windows
+    type: desktop
+  - target: mobile-passbolt-ios
+    type: mobile
+  - target: mobile-passbolt-android
+    type: mobile
+  out_of_scope:
+  - Passbolt network, online services, websites and related third-party services
+  - Vulnerabilities in third-party dependencies
+  - Vulnerabilities in development environments
+  - Vulnerabilities that require physical access
+  - Vulnerabilities that require social engineering
+  - Vulnerabilities that require unrealistic user interaction
+  - Vulnerabilities that are already known to us
+  - Vulnerabilities that are not reproducible
+  response_sla_days: 2
+
 - company: Pathé
   url: https://www.pathe.com/wp-content/uploads/2023/12/Pathe-Politique-CVD.1.2.EN_.pdf
   rewards:

--- a/independent-programs.yml
+++ b/independent-programs.yml
@@ -1507,6 +1507,13 @@ companies:
   - phishing
   - physical_access
 
+- company: Pulumi
+  url: https://www.pulumi.com/security/
+  contact: mailto:security@pulumi.com
+  program_type: vdp
+  status: active
+  description: Pulumi asks security researchers to email reports of vulnerabilities in its platform or services to its security address, including a description of the vulnerability, the impacted software or service and its version, and proof-of-concept code or detailed steps to reproduce. Reports can be encrypted with the PGP key published on the same page. Public security notifications are posted in the Pulumi Community Slack.
+
 - company: Recap Innovations
   url: https://recap-innovations.com/security/
   contact: mailto:security@recap-innovations.com


### PR DESCRIPTION
Two independent ones, neither looks to be on a platform as far as I could see.

- Passbolt - https://www.passbolt.com/docs/contribute/security/vulnerability/
- Pulumi - https://www.pulumi.com/security/

Passbolts the fuller of the two: scope table, 48h ack, credit but no money. Pulumis is thin by comparison, just a reporting process and a PGP key, no rewards mentioned so I left the payout fields out.

PGP key and preferred language for Passbolt came from thier `security.txt`.