### PR TITLE
Fix search dropdown options visibility

### DIFF
--- a/web/src/components/SearchableList.svelte
+++ b/web/src/components/SearchableList.svelte
@@ -329,8 +329,8 @@
     cursor: pointer;
   }
   .search-row select option {
-    color: #111;
-    background: #fff;
+    color: var(--background);
+    background: var(--foreground);
   }
   .chip-row {
     display: flex;

--- a/web/src/components/SearchableList.svelte
+++ b/web/src/components/SearchableList.svelte
@@ -328,6 +328,10 @@
     background: var(--background-lighter);
     cursor: pointer;
   }
+  .search-row select option {
+    color: #111;
+    background: #fff;
+  }
   .chip-row {
     display: flex;
     flex-wrap: wrap;


### PR DESCRIPTION
## Description
Fixes an issue where the search/sort dropdown options were not visible when the dropdown was opened.
The options appeared white against a white background and only became visible when hovered.

## Changes
- Added explicit text and background colors for the dropdown options.
- Verified the options are visible when the dropdown is opened.

## PoC
Before the fix, the dropdown options were not readable until hovered.
After the fix, the options are clearly visible when the dropdown is opened.

https://github.com/user-attachments/assets/dacb4075-4c3a-43ec-a321-1c5d807a0ef1

## Testing
Tested locally in Chrome and confirmed that all sort options are readable when the dropdown is opened.