### PR TITLE
Clearer deployment docs and usage

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -2174,13 +2174,18 @@ Start by clone the repo with `git clone git@github.com:Lissy93/bug-bounties.git 
 #### Website
 1. `cd web` to navigate into the [`web/`](https://github.com/Lissy93/bug-bounties/tree/main/web) directory
 2. `npm i` to install web NPM dependencies
-3. `npm run dev` to start the development server
-4. `npm run build` to build the production site
+3. `npm run dev` to start the development server, on [localhost:4321](http://localhost:4321)
+4. `npm run build` to build the production site, into `web/dist/`
+5. `npm start` to serve that build, on [localhost:8080](http://localhost:8080) (override with `HOST` / `PORT`)
 
 #### Deployment
-- Option 1) Upload the content of `web/dist/` into any web server, static hosting provider or CDN
+The build target is picked up from the environment, so no config is needed for the common cases.
+Set `DEPLOY_TARGET` to `node`, `vercel`, `netlify` or `static` to choose it explicitly.
+
+- Option 1) Self-host on Node: `npm run build && npm start` (uses [`server.mjs`](https://github.com/Lissy93/bug-bounties/blob/main/web/server.mjs), which serves `dist/client/` and hands everything else to `dist/server/`)
 - Option 2) Import the project into Vercel or Netlify directly, where it will be automatically deployed
 - Option 3) For Docker, run `docker run -p 8080:8080 ghcr.io/lissy93/bug-bounties:latest`
+- Option 4) Build with `DEPLOY_TARGET=static` and upload `web/dist/` to any static host or CDN. Note that this drops the server-rendered routes (`/lookup/*` and `/api/programs/search.json`)
 
 ---
 

--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -8,7 +8,7 @@ const target = (
 	(process.env.NETLIFY ? 'netlify' : '') ||
 	(process.env.VERCEL ? 'vercel' : '') ||
 	(process.env.NODE_ADAPTER ? 'node' : '') ||
-	'vercel'
+	'node'
 ).toLowerCase();
 
 async function resolveAdapter() {

--- a/web/package.json
+++ b/web/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "dev": "astro dev",
-    "start": "astro dev",
+    "start": "node ./server.mjs",
     "build": "astro check && astro build",
     "preview": "astro preview",
     "astro": "astro",

--- a/web/server.mjs
+++ b/web/server.mjs
@@ -1,7 +1,20 @@
+import { existsSync } from 'node:fs';
 import { createServer } from 'node:http';
 import { fileURLToPath } from 'node:url';
 import sirv from 'sirv';
-import { handler as ssr } from './dist/server/entry.mjs';
+
+const clientDir = fileURLToPath(new URL('./dist/client/', import.meta.url));
+const serverEntry = new URL('./dist/server/entry.mjs', import.meta.url);
+
+if (!existsSync(serverEntry) || !existsSync(clientDir)) {
+	console.error(
+		'No build found in ./dist - run `npm run build` before `npm start`.\n' +
+			'(if DEPLOY_TARGET is set, it must be `node` for this server)',
+	);
+	process.exit(1);
+}
+
+const { handler: ssr } = await import(serverEntry);
 
 const host = process.env.HOST ?? '0.0.0.0';
 const port = Number(process.env.PORT ?? 8080);
@@ -13,7 +26,6 @@ const securityHeaders = {
 	'Permissions-Policy': 'camera=(), microphone=(), geolocation=()',
 };
 
-const clientDir = fileURLToPath(new URL('./dist/client/', import.meta.url));
 const serveStatic = sirv(clientDir, {
 	etag: true,
 	gzip: true,


### PR DESCRIPTION
This PR makes easier for you to deploy yourself on bare metal:
- Updates deployment instructions in readme to make clearer
- Default mode now `NODE` so users don't need set no env vars
- Adds `npm start` command to serve up the compiled app
- Adds lil error message to explain what got fucked if breaks

Usage is really easy now
1. `cd web`
2. `npm install`
3. `npm run build`
4. `npm start`

The CDN method, the Vercel/Netlify method, and the Docker method (`docker run -p 8080:8080 ghcr.io/lissy93/bug-bounties:latest`) all remain unchanged.

Fixes #172